### PR TITLE
Adding 32-bit compatibility libraries

### DIFF
--- a/install_scripts/libs.sh
+++ b/install_scripts/libs.sh
@@ -11,6 +11,7 @@ RUN apt-get -q update && \
         gfortran \
         libopenblas-dev \
         openmpi-bin openmpi-common libopenmpi-dev \
+        libc6:i386 libncurses5:i386 libstdc++6:i386 \
         enchant \
         unixodbc unixodbc-dev && \
     rm -rf /var/lib/apt/lists/*

--- a/install_scripts/libs.sh
+++ b/install_scripts/libs.sh
@@ -3,7 +3,8 @@ RUN echo "" && \
     echo "INSTALLING COMMON LIBS" && \
     echo "======================" && \
     echo ""
-RUN apt-get -q update && \
+RUN dpkg --add-architecture i386 && \
+    apt-get -q update && \
     apt-get -q -y --no-install-recommends install \
         build-essential libssl-dev libffi-dev \
         wget zip unzip \


### PR DESCRIPTION
These libraries are required in the image so that Ubuntu will run 32-bit executables (like the GJH executable distributed by AMPL through netlib).